### PR TITLE
MacOS: Dont upgrade brew (automatically)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -189,7 +189,6 @@ runs:
           sudo apt-get -qq install freeglut3-dev libopengl0
           sudo apt-get -qq install libpng-dev libjpeg-dev libtiff-dev libglew-dev zlib1g-dev
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
-          brew update && brew upgrade
           brew install ccache ninja
           brew install glew
         elif [[ "$RUNNER_OS" == "Windows" ]]; then


### PR DESCRIPTION
IMO, no need to upgrade all the packages already installed in the github's macos image.

This allows:
 - faster time (less usage of compute minutes)
 - more importantly, it should avoid the shenanigans due to the upgrade (removing links, etc)


Used here https://github.com/sofa-framework/SofaGLFW/pull/91