### PR TITLE
Upgrade pybind to 2.6.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     default: 'latest'
   pybind11_version:
     description: 'pybind11 version to install'
-    default: '2.4.3'
+    default: '2.6.2'
   qt_version:
     description: 'Qt version to install'
     default: '5.12.8'


### PR DESCRIPTION
SofaPython3 on the CI jenkins is compiled with 2.6.2 so projects using it needs (at least?) 2.6.2 too

https://github.com/sofa-framework/SofaPython3/blob/bb7d9fd049a33fbdbe3f250f7ccd2b950daa716e/SofaPython3Config.cmake.in#L43C28-L43C44